### PR TITLE
Fixes incorrect column count on page load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,9 @@ const MasonryComponent = {
     }
   },
   mounted: function() {
-    this.reCalculate();
+    this.$nextTick(function () {
+      this.reCalculate();
+    });
 
     if(window) {
       window.addEventListener('resize', this.reCalculate);


### PR DESCRIPTION
I only observed this bug on chrome for android.
During the mounted handler, window.innerWidth was
being reported incorrectly causing the wrong
number of columns to render.  Moving the
calulation into the next tick resolved the
problem. The approach was taken from
https://github.com/vuejs/Discussion/issues/394